### PR TITLE
Detect fence agents container exit code

### DIFF
--- a/manifests/rbac.yaml.in
+++ b/manifests/rbac.yaml.in
@@ -26,6 +26,7 @@ rules:
       - ''
     resources:
       - nodes
+      - pods
     verbs:
       - list
       - watch


### PR DESCRIPTION
For the node with power-off state fencing `status` command
returns exit code 2, we need to detect it to prevent fake
job failure.

Node: It temporary solution, until we will refactor fencing logic.