### PR TITLE
Set user and service account on the job pod

### DIFF
--- a/manifests/rbac.yaml.in
+++ b/manifests/rbac.yaml.in
@@ -50,14 +50,6 @@ rules:
       - watch
       - get
 ---
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: cluster-api-provider-external
-  namespace: {{.Namespace}}
-  labels:
-    kubevirt.io: "cluster-api-provider-external"
----
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
@@ -72,3 +64,19 @@ subjects:
   - kind: ServiceAccount
     name: cluster-api-provider-external
     namespace: {{.Namespace}}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cluster-api-provider-external
+  namespace: {{.Namespace}}
+  labels:
+    kubevirt.io: "cluster-api-provider-external"
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ansible-job
+  namespace: {{.Namespace}}
+  labels:
+    kubevirt.io: "cluster-api-provider-external"

--- a/pkg/apis/providerconfig/v1alpha1/types.go
+++ b/pkg/apis/providerconfig/v1alpha1/types.go
@@ -21,6 +21,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const ServiceAccountAnsibleJob = "ansible-job"
+
 // The MachineRole indicates the purpose of the Machine, and will determine
 // what software and configuration will be used when provisioning and managing
 // the Machine. A single Machine may have more than one role, and the list and

--- a/pkg/external/pod.go
+++ b/pkg/external/pod.go
@@ -63,6 +63,8 @@ func createFencingJob(action string, machine *clusterv1.Machine, fencingConfig *
 
 	timeout := int64(30) // TODO: Make this configurable
 	numContainers := int32(1)
+	_true := true
+	userUID := int64(1001)
 
 	// Parallel Jobs with a fixed completion count
 	// - https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/
@@ -85,6 +87,11 @@ func createFencingJob(action string, machine *clusterv1.Machine, fencingConfig *
 			// TTLSecondsAfterFinished: 100,
 			Template: v1.PodTemplateSpec{
 				Spec: v1.PodSpec{
+					ServiceAccountName: v1alpha1.ServiceAccountAnsibleJob,
+					SecurityContext: &v1.PodSecurityContext{
+						RunAsUser: &userUID,
+						RunAsNonRoot: &_true,
+					},
 					Containers:    containers,
 					RestartPolicy: v1.RestartPolicyOnFailure,
 					Volumes:       volumes,


### PR DESCRIPTION
We need to add documentation note. To run `cluster-api-provider-external` you need to provide `scc` to service accounts `cluster-api-provider-external` and `ansible-job`.