### PR TITLE
Improve fencing jobs purging

### DIFF
--- a/pkg/apis/providerconfig/v1alpha1/types.go
+++ b/pkg/apis/providerconfig/v1alpha1/types.go
@@ -120,6 +120,10 @@ type FencingConfig struct {
 	// Volumes represent additional volumes that you want to attach
 	// to the container
 	Volumes []v1.Volume `json:"volumes,omitempty"`
+
+	// Defines whether successful Jobs should be removed automatically
+	// Might be usefull to turn off for debugging purposes
+	NoSuccessfulJobsCleanup bool `json:"noSuccessfulJobsCleanup,omitempty"`
 }
 
 type DynamicConfigElement struct {


### PR DESCRIPTION
Pods of successful jobs are removed together with its jobs.
New config option has been added. It is now possible to turn off jobs cleanup, as it is enabled by default.